### PR TITLE
PEP8 generator_helper.py. Fix invalid name generation.

### DIFF
--- a/tests/utils/test_generator_helper.py
+++ b/tests/utils/test_generator_helper.py
@@ -1,6 +1,21 @@
+# encoding: utf-8
 from collections import OrderedDict
 from zerotest.request import Request
-from zerotest.utils.generator_helper import get_name_from_request, dict_to_param_style_code
+from zerotest.utils.generator_helper import (
+    get_name_from_request,
+    dict_to_param_style_code
+)
+
+
+#: Common HTTP request path characters that are invalid when used for
+#: a python function name.
+INVALID_CHARS = (
+    '*',
+    '-',
+    '#',
+    '/',
+    '.'
+)
 
 
 def test_get_name_from_request():
@@ -8,6 +23,16 @@ def test_get_name_from_request():
     assert get_name_from_request(req) == 'get_root'
     req = Request(path='/the/world', method='PUT')
     assert get_name_from_request(req) == 'put_the_world'
+
+    for invalid_char in INVALID_CHARS:
+        assert(
+            get_name_from_request(
+                Request(
+                    path='/bad_{0}_trailing'.format(invalid_char),
+                    method='GET'
+                )
+            ) == 'get_bad_trailing'
+        )
 
 
 def test_dict_to_param_style_code():

--- a/zerotest/utils/generator_helper.py
+++ b/zerotest/utils/generator_helper.py
@@ -3,6 +3,7 @@
 import re
 
 INVALID_METHOD_R = re.compile(r'[^a-zA-Z0-9_]')
+MULTI_UNDERSCORE_R = re.compile(r'[_]+')
 
 
 def get_name_from_request(request):
@@ -28,7 +29,21 @@ def _path_to_func_name(path):
     :type path: unicode
     :rtype: unicode
     """
-    return 'root' if path == '/' else INVALID_METHOD_R.sub('_', path)
+    if path == '/':
+        return 'root'
+
+    # Replace any occurances of more than one underscore with a single
+    # instance. (ex: path = '/#anchor' -> '__anchor')
+    clean_path = MULTI_UNDERSCORE_R.sub(
+        '_',
+        # Replace any invalid method name characters with an underscore.
+        INVALID_METHOD_R.sub(
+            '_',
+            path
+        )
+    )
+
+    return clean_path[1:] if clean_path.startswith(u'_') else clean_path
 
 
 def dict_to_param_style_code(d):

--- a/zerotest/utils/generator_helper.py
+++ b/zerotest/utils/generator_helper.py
@@ -1,18 +1,35 @@
-__author__ = 'Hari Jiang'
+#!/usr/bin/env python
+# encoding: utf-8
+import re
+
+INVALID_METHOD_R = re.compile(r'[^a-zA-Z0-9_]')
 
 
 def get_name_from_request(request):
-    return '{}_{}'.format(request.method.lower(), _path_to_func_name(request.path))
+    return '{}_{}'.format(
+        request.method.lower(),
+        _path_to_func_name(request.path)
+    )
 
 
 def _path_to_func_name(path):
-    if path == '/':
-        name = 'root'
-    else:
-        name = path[1:].replace('/', '_').replace('-', '_')
-    return name
+    """
+    Generate a valid python function name for a given request path.
+
+    The valid characters for a Python 2 function name are defined as follows:
+
+    identifier ::=  (letter|"_") (letter | digit | "_")*
+    letter     ::=  lowercase | uppercase
+    lowercase  ::=  "a"..."z"
+    uppercase  ::=  "A"..."Z"
+    digit      ::=  "0"..."9"
+
+    :param path: The HTTP request path string.
+    :type path: unicode
+    :rtype: unicode
+    """
+    return 'root' if path == '/' else INVALID_METHOD_R.sub('_', path)
 
 
 def dict_to_param_style_code(d):
-    source = ", ".join(map(lambda (k, v): "{}={}".format(k, repr(v)), d.items()))
-    return source
+    return ', '.join('{0}={1}'.format(k, repr(v)) for k, v in d.items())

--- a/zerotest/utils/generator_helper.py
+++ b/zerotest/utils/generator_helper.py
@@ -33,16 +33,14 @@ def _path_to_func_name(path):
 
     # Replace any occurances of more than one underscore with a single
     # instance. (ex: path = '/#anchor' -> '__anchor')
-    clean_path = MULTI_UNDERSCORE_R.sub(
+    return MULTI_UNDERSCORE_R.sub(
         '_',
         # Replace any invalid method name characters with an underscore.
         INVALID_METHOD_R.sub(
             '_',
             path
         )
-    )
-
-    return clean_path[1:] if clean_path.startswith(u'_') else clean_path
+    ).strip('_')
 
 
 def dict_to_param_style_code(d):


### PR DESCRIPTION
As pointed out [here](https://www.reddit.com/r/Python/comments/3t0j58/zerotest_lazy_guys_testing_tool_test_your_api/), it's possible to generate invalid method names. This PR corrects this. It also tidies up `generator_helper.py` for PEP8 violations.